### PR TITLE
feat: Revamp cashflow tables and transaction handling

### DIFF
--- a/cashflow/forms.py
+++ b/cashflow/forms.py
@@ -49,12 +49,11 @@ class TransactionForm(forms.ModelForm):
     class Meta:
         model = Transaction
         fields = [
-            'transaction_date', 'safe', 
+            'safe', 
             'category', 'sub_category', 
             'amount', 'payment_method', 'contact', 'notes'
         ]
         widgets = {
-            'transaction_date': forms.DateTimeInput(attrs={'type': 'datetime-local', 'class': 'form-control'}),
             'safe': forms.Select(attrs={'class': 'form-select'}),
             'category': forms.Select(attrs={'class': 'form-select'}),
             'sub_category': forms.Select(attrs={'class': 'form-select'}),
@@ -73,7 +72,7 @@ class TransactionForm(forms.ModelForm):
 
         # Order fields to place transaction_type_selector before category
         field_order = [
-            'transaction_date', 'safe', 'transaction_type_selector', 'category', 'sub_category',
+            'safe', 'transaction_type_selector', 'category', 'sub_category',
             'amount', 'payment_method', 'contact', 'notes'
         ]
         self.order_fields(field_order)

--- a/cashflow/templates/cashflow/base_cashflow.html
+++ b/cashflow/templates/cashflow/base_cashflow.html
@@ -48,7 +48,9 @@
             margin-right: 5px;
         }
     </style>
-    {% block extra_head %}{% endblock %}
+    {% block extra_head %}
+    <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/1.13.6/css/dataTables.bootstrap5.min.css">
+    {% endblock %}
 </head>
 <body>
     {% include 'cashflow/includes/navbar_cashflow.html' %}
@@ -77,6 +79,10 @@
     </footer>
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/js/bootstrap.bundle.min.js"></script>
-    {% block extra_js %}{% endblock %}
+    {% block extra_js %}
+    <script src="https://code.jquery.com/jquery-3.7.0.js"></script>
+    <script src="https://cdn.datatables.net/1.13.6/js/jquery.dataTables.min.js"></script>
+    <script src="https://cdn.datatables.net/1.13.6/js/dataTables.bootstrap5.min.js"></script>
+    {% endblock %}
 </body>
 </html>

--- a/cashflow/templates/cashflow/transaction_list.html
+++ b/cashflow/templates/cashflow/transaction_list.html
@@ -1,5 +1,5 @@
 {% extends "cashflow/base_cashflow.html" %}
-{% load i18n humanize %} {# Assuming you have django.contrib.humanize in INSTALLED_APPS #}
+{% load i18n humanize %}
 
 {% block title %}{{ page_title }} - {% trans "Cash Flow" %}{% endblock %}
 
@@ -16,7 +16,8 @@
                     </span>
                 </span>
                 {% endif %}
-                {% if today_net_flow is not None %}
+                {# Today's Net Flow might be less relevant with running balances, but kept if needed #}
+                {% if today_net_flow is not None %} 
                 <span class="fw-bold ms-3">{% trans "Today's Net Flow" %}: 
                     <span class="{% if today_net_flow >= 0 %}balance-positive{% else %}balance-negative{% endif %}">
                         {{ today_net_flow|floatformat:2|intcomma }}
@@ -27,49 +28,111 @@
         </div>
     </div>
     <div class="card-body">
-        {% if transactions %}
-            <div class="table-responsive">
-                <table class="table table-striped table-hover">
-                    <thead>
-                        <tr>
-                            <th>{% trans "Date" %}</th>
-                            <th>{% trans "Safe" %}</th>
-                            <th>{% trans "Type" %}</th>
-                            <th>{% trans "Category" %}</th>
-                            <th>{% trans "SubCategory" %}</th>
-                            <th class="text-end">{% trans "Amount" %}</th>
-                            <th>{% trans "Payment Method" %}</th>
-                            <th>{% trans "Contact" %}</th>
-                            <th>{% trans "User" %}</th>
-                            <th>{% trans "Actions" %}</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        {% for transaction in transactions %}
-                        <tr>
-                            <td>{{ transaction.transaction_date|date:"Y-m-d H:i" }}</td>
-                            <td>{{ transaction.safe.name }}</td>
-                            <td>{{ transaction.category.transaction_type.name }}</td>
-                            <td>{{ transaction.category.name }}</td>
-                            <td>{{ transaction.sub_category.name|default:"-" }}</td>
-                            <td class="text-end {% if transaction.category.transaction_type.name == _('Income') or transaction.category.transaction_type.name == _('Internal Transfer In') %}balance-positive{% elif transaction.category.transaction_type.name == _('Expense') or transaction.category.transaction_type.name == _('Internal Transfer Out') %}balance-negative{% endif %}">
-                                {{ transaction.amount|floatformat:2|intcomma }}
-                            </td>
-                            <td>{{ transaction.get_payment_method_display }}</td>
-                            <td>{{ transaction.contact.name|default:"-" }}</td>
-                            <td>{{ transaction.user.username|default:"-" }}</td>
-                            <td class="action-buttons">
-                                <a href="{% url 'cashflow:transaction_update' transaction.pk %}" class="btn btn-sm btn-outline-primary" title="{% trans 'Edit' %}"><i class="bi bi-pencil-square"></i></a>
-                                <a href="{% url 'cashflow:transaction_delete' transaction.pk %}" class="btn btn-sm btn-outline-danger" title="{% trans 'Delete' %}"><i class="bi bi-trash"></i></a>
-                            </td>
-                        </tr>
-                        {% endfor %}
-                    </tbody>
-                </table>
+        <ul class="nav nav-tabs" id="transactionTabs" role="tablist">
+            <li class="nav-item" role="presentation">
+                <button class="nav-link active" id="combined-tab" data-bs-toggle="tab" data-bs-target="#combined-tab-pane" type="button" role="tab" aria-controls="combined-tab-pane" aria-selected="true">{% trans "Combined" %}</button>
+            </li>
+            {% for safe_data in user_safes_with_transactions %}
+            <li class="nav-item" role="presentation">
+                <button class="nav-link" id="safe-{{ safe_data.safe_id }}-tab" data-bs-toggle="tab" data-bs-target="#safe-{{ safe_data.safe_id }}-tab-pane" type="button" role="tab" aria-controls="safe-{{ safe_data.safe_id }}-tab-pane" aria-selected="false">{{ safe_data.safe_name }}</button>
+            </li>
+            {% endfor %}
+        </ul>
+        <div class="tab-content" id="transactionTabsContent">
+            <!-- Combined Transactions Tab -->
+            <div class="tab-pane fade show active" id="combined-tab-pane" role="tabpanel" aria-labelledby="combined-tab" tabindex="0">
+                <div class="table-responsive mt-3">
+                    <table id="combinedTable" class="table table-striped table-hover">
+                        <thead>
+                            <tr>
+                                <th>{% trans "Date" %}</th>
+                                <th>{% trans "Safe" %}</th>
+                                <th>{% trans "Category" %}</th>
+                                <th>{% trans "SubCategory" %}</th>
+                                <th>{% trans "Notes" %}</th>
+                                <th class="text-end">{% trans "Debit" %}</th>
+                                <th class="text-end">{% trans "Credit" %}</th>
+                                <th class="text-end">{% trans "Balance" %}</th>
+                                <th>{% trans "Actions" %}</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {% for transaction in combined_transactions_with_balance %}
+                            <tr>
+                                <td>{{ transaction.transaction_date|date:"Y-m-d H:i" }}</td>
+                                <td>{{ transaction.safe.name }}</td>
+                                <td>{{ transaction.category.name }}</td>
+                                <td>{{ transaction.sub_category.name|default:"-" }}</td>
+                                <td>{{ transaction.notes|default:"-" }}</td>
+                                <td class="text-end">
+                                    {% if transaction.category.type == Category.TRANSACTION_TYPE_EXPENSE %}{{ transaction.amount|floatformat:2|intcomma }}{% endif %}
+                                </td>
+                                <td class="text-end">
+                                    {% if transaction.category.type == Category.TRANSACTION_TYPE_INCOME %}{{ transaction.amount|floatformat:2|intcomma }}{% endif %}
+                                </td>
+                                <td class="text-end">{{ transaction.running_balance|floatformat:2|intcomma }}</td>
+                                <td class="action-buttons">
+                                    {% if user.is_superuser or transaction.transaction_date.date == current_date %}
+                                        <a href="{% url 'cashflow:transaction_update' transaction.pk %}" class="btn btn-sm btn-outline-primary" title="{% trans 'Edit' %}"><i class="bi bi-pencil-square"></i></a>
+                                        <a href="{% url 'cashflow:transaction_delete' transaction.pk %}" class="btn btn-sm btn-outline-danger" title="{% trans 'Delete' %}"><i class="bi bi-trash"></i></a>
+                                    {% else %}
+                                        <span class="text-muted">{% trans "Locked" %}</span>
+                                    {% endif %}
+                                </td>
+                            </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                </div>
             </div>
-        {% else %}
-            <p class="text-center">{% trans "No transactions found." %}</p>
-        {% endif %}
+
+            <!-- Individual Safe Tabs -->
+            {% for safe_data in user_safes_with_transactions %}
+            <div class="tab-pane fade" id="safe-{{ safe_data.safe_id }}-tab-pane" role="tabpanel" aria-labelledby="safe-{{ safe_data.safe_id }}-tab" tabindex="0">
+                <div class="table-responsive mt-3">
+                    <table id="safeTable{{ safe_data.safe_id }}" class="table table-striped table-hover">
+                        <thead>
+                            <tr>
+                                <th>{% trans "Date" %}</th>
+                                <th>{% trans "Category" %}</th>
+                                <th>{% trans "SubCategory" %}</th>
+                                <th>{% trans "Notes" %}</th>
+                                <th class="text-end">{% trans "Debit" %}</th>
+                                <th class="text-end">{% trans "Credit" %}</th>
+                                <th class="text-end">{% trans "Balance" %}</th>
+                                <th>{% trans "Actions" %}</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {% for transaction in safe_data.transactions %}
+                            <tr>
+                                <td>{{ transaction.transaction_date|date:"Y-m-d H:i" }}</td>
+                                <td>{{ transaction.category.name }}</td>
+                                <td>{{ transaction.sub_category.name|default:"-" }}</td>
+                                <td>{{ transaction.notes|default:"-" }}</td>
+                                <td class="text-end">
+                                    {% if transaction.category.type == Category.TRANSACTION_TYPE_EXPENSE %}{{ transaction.amount|floatformat:2|intcomma }}{% endif %}
+                                </td>
+                                <td class="text-end">
+                                    {% if transaction.category.type == Category.TRANSACTION_TYPE_INCOME %}{{ transaction.amount|floatformat:2|intcomma }}{% endif %}
+                                </td>
+                                <td class="text-end">{{ transaction.running_balance|floatformat:2|intcomma }}</td>
+                                <td class="action-buttons">
+                                    {% if user.is_superuser or transaction.transaction_date.date == current_date %}
+                                        <a href="{% url 'cashflow:transaction_update' transaction.pk %}" class="btn btn-sm btn-outline-primary" title="{% trans 'Edit' %}"><i class="bi bi-pencil-square"></i></a>
+                                        <a href="{% url 'cashflow:transaction_delete' transaction.pk %}" class="btn btn-sm btn-outline-danger" title="{% trans 'Delete' %}"><i class="bi bi-trash"></i></a>
+                                    {% else %}
+                                        <span class="text-muted">{% trans "Locked" %}</span>
+                                    {% endif %}
+                                </td>
+                            </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+            {% endfor %}
+        </div>
     </div>
     <div class="card-footer text-center">
         <a href="{% url 'cashflow:transaction_create' %}" class="btn btn-success">
@@ -77,4 +140,20 @@
         </a>
     </div>
 </div>
+{% endblock %}
+
+{% block extra_js %}
+{{ block.super }} {# Includes scripts from base_cashflow.html #}
+<script>
+$(document).ready(function() {
+    $('#combinedTable').DataTable({
+        "order": [[ 0, "desc" ]] // Order by date descending
+    });
+    {% for safe_data in user_safes_with_transactions %}
+    $('#safeTable{{ safe_data.safe_id }}').DataTable({
+        "order": [[ 0, "desc" ]] // Order by date descending
+    });
+    {% endfor %}
+});
+</script>
 {% endblock %}

--- a/cashflow/tests.py
+++ b/cashflow/tests.py
@@ -1,3 +1,299 @@
-from django.test import TestCase
+from django.test import TestCase, Client
+from django.urls import reverse
+from django.utils import timezone
+from decimal import Decimal
+from django.contrib.auth.models import User
+from .models import Safe, Category, Transaction, UserSafeAssignment
 
-# Create your tests here.
+# --- Helper Functions ---
+def create_user(username='testuser', is_superuser=False):
+    return User.objects.create_user(username=username, password='password', is_superuser=is_superuser)
+
+def create_category(name, type):
+    return Category.objects.create(name=name, type=type)
+
+def create_safe(name='Test Safe'):
+    return Safe.objects.create(name=name)
+
+class TransactionFormTests(TestCase):
+    def setUp(self):
+        self.user = create_user()
+        self.client = Client()
+        self.client.login(username='testuser', password='password')
+        self.safe = create_safe()
+        # Assign safe to user (assuming non-superuser needs assignment)
+        UserSafeAssignment.objects.create(user=self.user, safe=self.safe)
+        self.income_category = create_category('Salary', Category.TRANSACTION_TYPE_INCOME)
+
+    def test_transaction_date_not_in_form(self):
+        from .forms import TransactionForm
+        form = TransactionForm(user=self.user)
+        self.assertNotIn('transaction_date', form.fields)
+
+    def test_transaction_create_view_sets_date_and_user(self):
+        transaction_data = {
+            'safe': self.safe.pk,
+            'transaction_type_selector': Category.TRANSACTION_TYPE_INCOME, # From the form
+            'category': self.income_category.pk,
+            'amount': Decimal('1000.00'),
+            'payment_method': Transaction.PAYMENT_METHOD_BANK,
+            # 'notes': 'Test income', # Optional
+        }
+        
+        response = self.client.post(reverse('cashflow:transaction_create'), data=transaction_data)
+        
+        self.assertEqual(response.status_code, 302, "Should redirect after successful creation") # Redirects to list view
+        self.assertTrue(Transaction.objects.exists(), "Transaction should be created")
+        
+        transaction = Transaction.objects.first()
+        self.assertEqual(transaction.safe, self.safe)
+        self.assertEqual(transaction.category, self.income_category)
+        self.assertEqual(transaction.amount, Decimal('1000.00'))
+        
+        # Verify transaction_date is set to timezone.now() (approximately)
+        self.assertIsNotNone(transaction.transaction_date)
+        self.assertEqual(transaction.transaction_date.date(), timezone.now().date())
+        # Check if the time is recent (e.g., within the last 5 seconds)
+        time_difference = timezone.now() - transaction.transaction_date
+        self.assertTrue(time_difference.total_seconds() < 5, "Transaction time should be very recent")
+        
+        # Verify transaction.user is set to the logged-in user
+        self.assertEqual(transaction.user, self.user)
+
+class TransactionListViewTests(TestCase):
+    def setUp(self):
+        self.user = create_user(username='listviewuser')
+        self.client = Client()
+        self.client.login(username='listviewuser', password='password')
+        
+        self.safe1 = create_safe(name='Safe Alpha')
+        UserSafeAssignment.objects.create(user=self.user, safe=self.safe1)
+
+        self.income_cat = create_category('Consulting Income', Category.TRANSACTION_TYPE_INCOME)
+        self.expense_cat = create_category('Office Supplies', Category.TRANSACTION_TYPE_EXPENSE)
+
+        # Create transactions with specific dates and amounts for predictable ordering and balance
+        # Transactions are created in chronological order for easier balance calculation logic
+        # They will be sorted by date descending in the view for display
+        self.t1_income = Transaction.objects.create(
+            user=self.user, safe=self.safe1, category=self.income_cat, 
+            amount=Decimal('500.00'), transaction_date=timezone.now() - timezone.timedelta(days=2)
+        )
+        self.t2_expense = Transaction.objects.create(
+            user=self.user, safe=self.safe1, category=self.expense_cat,
+            amount=Decimal('50.00'), transaction_date=timezone.now() - timezone.timedelta(days=1)
+        )
+        self.t3_income = Transaction.objects.create(
+            user=self.user, safe=self.safe1, category=self.income_cat,
+            amount=Decimal('200.00'), transaction_date=timezone.now() 
+        )
+        # Expected running balances (chronological):
+        # t1: 500.00
+        # t2: 500.00 - 50.00 = 450.00
+        # t3: 450.00 + 200.00 = 650.00
+
+    def test_running_balance_single_safe_and_data_integrity(self):
+        response = self.client.get(reverse('cashflow:transaction_list'))
+        self.assertEqual(response.status_code, 200)
+
+        context = response.context
+        self.assertIn('user_safes_with_transactions', context)
+        
+        user_safes_data = context['user_safes_with_transactions']
+        self.assertEqual(len(user_safes_data), 1) # Only one safe assigned/created for this user
+
+        safe1_data = user_safes_data[0]
+        self.assertEqual(safe1_data['safe_name'], self.safe1.name)
+        
+        # Transactions are displayed in reverse chronological order
+        displayed_transactions = safe1_data['transactions'] 
+        self.assertEqual(len(displayed_transactions), 3)
+
+        # Check transactions and their running balances (order is reversed from creation)
+        # Transaction t3 (latest)
+        self.assertEqual(displayed_transactions[0].pk, self.t3_income.pk)
+        self.assertEqual(displayed_transactions[0].running_balance, Decimal('650.00'))
+        self.assertEqual(displayed_transactions[0].category.type, Category.TRANSACTION_TYPE_INCOME)
+        self.assertEqual(displayed_transactions[0].amount, Decimal('200.00'))
+
+
+        # Transaction t2 (middle)
+        self.assertEqual(displayed_transactions[1].pk, self.t2_expense.pk)
+        self.assertEqual(displayed_transactions[1].running_balance, Decimal('450.00'))
+        self.assertEqual(displayed_transactions[1].category.type, Category.TRANSACTION_TYPE_EXPENSE)
+        self.assertEqual(displayed_transactions[1].amount, Decimal('50.00'))
+
+        # Transaction t1 (oldest)
+        self.assertEqual(displayed_transactions[2].pk, self.t1_income.pk)
+        self.assertEqual(displayed_transactions[2].running_balance, Decimal('500.00'))
+        self.assertEqual(displayed_transactions[2].category.type, Category.TRANSACTION_TYPE_INCOME)
+        self.assertEqual(displayed_transactions[2].amount, Decimal('500.00'))
+
+        # Test combined view as well (since it's part of the same view logic)
+        self.assertIn('combined_transactions_with_balance', context)
+        combined_transactions = context['combined_transactions_with_balance']
+        self.assertEqual(len(combined_transactions), 3)
+
+        # Check running balances in combined view (should be the same as single safe in this case)
+        self.assertEqual(combined_transactions[0].pk, self.t3_income.pk)
+        self.assertEqual(combined_transactions[0].running_balance, Decimal('650.00'))
+        self.assertEqual(combined_transactions[1].pk, self.t2_expense.pk)
+        self.assertEqual(combined_transactions[1].running_balance, Decimal('450.00'))
+        self.assertEqual(combined_transactions[2].pk, self.t1_income.pk)
+        self.assertEqual(combined_transactions[2].running_balance, Decimal('500.00'))
+        
+        # Check Category model is passed for template logic
+        self.assertIn('Category', context)
+        self.assertEqual(context['Category'], Category)
+
+
+class TransactionPermissionTests(TestCase):
+    def setUp(self):
+        self.superuser = create_user(username='superuser', is_superuser=True)
+        self.regular_user = create_user(username='regularuser')
+        
+        self.safe = create_safe()
+        # Assign safe to both users for simplicity in testing actions
+        UserSafeAssignment.objects.create(user=self.superuser, safe=self.safe)
+        UserSafeAssignment.objects.create(user=self.regular_user, safe=self.safe)
+
+        self.category = create_category('General', Category.TRANSACTION_TYPE_INCOME)
+
+        self.transaction_yesterday = Transaction.objects.create(
+            user=self.regular_user, # or superuser, doesn't matter for ownership here
+            safe=self.safe,
+            category=self.category,
+            amount=Decimal('100.00'),
+            transaction_date=timezone.now() - timezone.timedelta(days=1)
+        )
+        self.transaction_today = Transaction.objects.create(
+            user=self.regular_user, # or superuser
+            safe=self.safe,
+            category=self.category,
+            amount=Decimal('200.00'),
+            transaction_date=timezone.now()
+        )
+        
+        self.update_url_yesterday = reverse('cashflow:transaction_update', kwargs={'pk': self.transaction_yesterday.pk})
+        self.delete_url_yesterday = reverse('cashflow:transaction_delete', kwargs={'pk': self.transaction_yesterday.pk})
+        self.update_url_today = reverse('cashflow:transaction_update', kwargs={'pk': self.transaction_today.pk})
+        self.delete_url_today = reverse('cashflow:transaction_delete', kwargs={'pk': self.transaction_today.pk})
+        
+        self.list_url = reverse('cashflow:transaction_list')
+
+    def test_superuser_permissions(self):
+        self.client.login(username='superuser', password='password')
+        
+        # Can access update/delete views for yesterday's transaction
+        response_update_get_yesterday = self.client.get(self.update_url_yesterday)
+        self.assertEqual(response_update_get_yesterday.status_code, 200)
+        response_delete_get_yesterday = self.client.get(self.delete_url_yesterday)
+        self.assertEqual(response_delete_get_yesterday.status_code, 200)
+
+        # Can access update/delete views for today's transaction
+        response_update_get_today = self.client.get(self.update_url_today)
+        self.assertEqual(response_update_get_today.status_code, 200)
+        response_delete_get_today = self.client.get(self.delete_url_today)
+        self.assertEqual(response_delete_get_today.status_code, 200)
+
+        # Superuser can successfully delete yesterday's transaction
+        response_delete_post_yesterday = self.client.post(self.delete_url_yesterday)
+        self.assertEqual(response_delete_post_yesterday.status_code, 302) # Redirects to list
+        self.assertFalse(Transaction.objects.filter(pk=self.transaction_yesterday.pk).exists())
+
+        # Superuser can successfully update today's transaction (form data would be needed for full update)
+        # For simplicity, we'll just check the POST access and redirect
+        update_data = {
+            'safe': self.safe.pk,
+            'transaction_type_selector': self.category.type,
+            'category': self.category.pk,
+            'amount': Decimal('250.00'), # Changed amount
+            'payment_method': Transaction.PAYMENT_METHOD_CASH,
+        }
+        response_update_post_today = self.client.post(self.update_url_today, data=update_data)
+        self.assertEqual(response_update_post_today.status_code, 302) # Redirects
+        updated_transaction_today = Transaction.objects.get(pk=self.transaction_today.pk)
+        self.assertEqual(updated_transaction_today.amount, Decimal('250.00'))
+
+
+    def test_regular_user_permissions(self):
+        self.client.login(username='regularuser', password='password')
+
+        # Regular user CANNOT access update/delete views for yesterday's transaction (GET)
+        response_update_get_yesterday = self.client.get(self.update_url_yesterday)
+        self.assertEqual(response_update_get_yesterday.status_code, 302) # Redirect
+        self.assertEqual(response_update_get_yesterday.url, self.list_url)
+        
+        response_delete_get_yesterday = self.client.get(self.delete_url_yesterday)
+        self.assertEqual(response_delete_get_yesterday.status_code, 302) # Redirect
+        self.assertEqual(response_delete_get_yesterday.url, self.list_url)
+        
+        # Check for messages (this requires middleware and settings to be right for messages to appear in test client)
+        # For now, we'll assume the redirect implies the message was set.
+        # A more robust way is to check messages in the response context if available, or use a MessageTestMixin.
+
+        # Regular user CAN access update/delete views for today's transaction (GET)
+        response_update_get_today = self.client.get(self.update_url_today)
+        self.assertEqual(response_update_get_today.status_code, 200)
+        response_delete_get_today = self.client.get(self.delete_url_today)
+        self.assertEqual(response_delete_get_today.status_code, 200)
+
+        # Regular user CANNOT delete yesterday's transaction (POST)
+        response_delete_post_yesterday = self.client.post(self.delete_url_yesterday)
+        self.assertEqual(response_delete_post_yesterday.status_code, 302) # Redirect
+        self.assertEqual(response_delete_post_yesterday.url, self.list_url)
+        self.assertTrue(Transaction.objects.filter(pk=self.transaction_yesterday.pk).exists()) # Still exists
+
+        # Regular user CANNOT update yesterday's transaction (POST)
+        update_data_yesterday = {
+            'safe': self.safe.pk,
+            'transaction_type_selector': self.category.type,
+            'category': self.category.pk,
+            'amount': Decimal('150.00'),
+            'payment_method': Transaction.PAYMENT_METHOD_CASH,
+        }
+        response_update_post_yesterday = self.client.post(self.update_url_yesterday, data=update_data_yesterday)
+        self.assertEqual(response_update_post_yesterday.status_code, 302) # Redirect
+        self.assertEqual(response_update_post_yesterday.url, self.list_url)
+        self.transaction_yesterday.refresh_from_db()
+        self.assertEqual(self.transaction_yesterday.amount, Decimal('100.00')) # Amount unchanged
+
+        # Regular user CAN successfully delete today's transaction
+        # Need to re-create today's transaction as it might have been updated by superuser test if tests run in certain order
+        # Best practice: ensure tests are isolated or re-initialize state. For now, we'll assume it's there.
+        # If transaction_today was deleted by superuser test, this will fail.
+        # Let's ensure it exists or re-create for this specific test path
+        if not Transaction.objects.filter(pk=self.transaction_today.pk).exists():
+             self.transaction_today = Transaction.objects.create(
+                user=self.regular_user, safe=self.safe, category=self.category,
+                amount=Decimal('200.00'), transaction_date=timezone.now()
+            )
+        
+        response_delete_post_today = self.client.post(reverse('cashflow:transaction_delete', kwargs={'pk': self.transaction_today.pk}))
+        self.assertEqual(response_delete_post_today.status_code, 302) # Redirects
+        self.assertFalse(Transaction.objects.filter(pk=self.transaction_today.pk).exists())
+
+        # Regular user CAN successfully update today's transaction
+        # Re-create today's transaction if it was deleted above
+        self.transaction_today = Transaction.objects.create(
+            user=self.regular_user, safe=self.safe, category=self.category,
+            amount=Decimal('200.00'), transaction_date=timezone.now()
+        )
+        update_data_today = {
+            'safe': self.safe.pk,
+            'transaction_type_selector': self.category.type,
+            'category': self.category.pk,
+            'amount': Decimal('220.00'),
+            'payment_method': Transaction.PAYMENT_METHOD_BANK,
+        }
+        response_update_post_today = self.client.post(reverse('cashflow:transaction_update', kwargs={'pk': self.transaction_today.pk}), data=update_data_today)
+        self.assertEqual(response_update_post_today.status_code, 302) # Redirects
+        updated_transaction_today = Transaction.objects.get(pk=self.transaction_today.pk)
+        self.assertEqual(updated_transaction_today.amount, Decimal('220.00'))
+
+    def test_current_date_in_list_view_context(self):
+        self.client.login(username='regularuser', password='password')
+        response = self.client.get(self.list_url)
+        self.assertEqual(response.status_code, 200)
+        self.assertIn('current_date', response.context)
+        self.assertEqual(response.context['current_date'], timezone.now().date())


### PR DESCRIPTION
I've implemented several enhancements to the cashflow module:

1.  **Accounting Standard Tables:**
    *   Transaction tables now display "Debit", "Credit," and running "Balance" columns.
    *   Debit/Credit is determined by the transaction category (Income/Expense).
    *   The running balance is calculated per safe and for a combined view.

2.  **DataTables Integration:**
    *   All transaction tables (per-safe and combined) now use DataTables.
    *   This includes search functionality for each table.
    *   Safes are displayed in separate tabs, with an additional "Combined" tab.

3.  **Transaction Entry:**
    *   I've removed the `transaction_date` field from the new entry form.
    *   The system now automatically uses the current date and time of entry.
    *   Existing transaction dates are not editable through the form.

4.  **Permissions for Edit/Delete:**
    *   Superusers can edit or delete any transaction.
    *   Regular users can only edit or delete transactions made on the current day.

5.  **Verification:**
    *   I've added automated checks for the new form logic, running balance calculations in views, and permission controls.